### PR TITLE
Pass agent observation_dtype to replay buffer

### DIFF
--- a/dopamine/agents/rainbow/rainbow_agent.py
+++ b/dopamine/agents/rainbow/rainbow_agent.py
@@ -194,7 +194,8 @@ class RainbowAgent(dqn_agent.DQNAgent):
         stack_size=self.stack_size,
         use_staging=use_staging,
         update_horizon=self.update_horizon,
-        gamma=self.gamma)
+        gamma=self.gamma,
+        observation_dtype=self.observation_dtype.as_numpy_dtype)
 
   def _build_target_distribution(self):
     """Builds the C51 target distribution as per Bellemare et al. (2017).


### PR DESCRIPTION
Fixes issue where rainbow's prioritized replay buffer silently cast observations to type np.uint8 instead of the environment's observation_dtype.